### PR TITLE
fix: pre-commitのdprintフックをnpxからnode言語管理に変更

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,8 @@ repos:
     hooks:
       - id: dprint
         name: dprint fmt
-        entry: npx dprint fmt
+        entry: dprint fmt
         args: ["--allow-no-files"]
-        language: system
+        language: node
+        additional_dependencies: ["dprint@0.55.2"]
+        pass_filenames: false


### PR DESCRIPTION
## Summary
- main上のCIが `dprint fmt` フックで `SyntaxError: Invalid or unexpected token` により継続的に失敗していた
- `entry: npx dprint fmt` / `language: system` はCI実行のたびにnpxがdprintをアドホックにダウンロードして実行する方式で、ネイティブバイナリの実行に失敗していた（GitHub ActionsのUbuntuランナー環境でのみ再現、macOSローカルでは再現せず）
- pre-commit標準の `language: node` + `additional_dependencies` に切り替え、依存インストールを確実に行う方式に変更

## Test plan
- [x] ローカルで `uvx pre-commit run --all-files` を実行し、yamllint/dprint fmt両方Passを確認
- [ ] CI(GitHub Actions)上でも `pre-commit` ジョブがPassすることを確認